### PR TITLE
Gtk warning filter needs to be a regex.

### DIFF
--- a/lib/cylc/gui/updater_dot.py
+++ b/lib/cylc/gui/updater_dot.py
@@ -27,7 +27,7 @@ from cylc.network.suite_state import get_id_summary
 from copy import deepcopy
 
 import warnings
-warnings.filterwarnings('ignore', 'was not found when attempting to remove it',
+warnings.filterwarnings('ignore', '^.*was not found when attempting to remove it',
                         Warning)
 
 


### PR DESCRIPTION
@oliver-sanders - I guess you're not seeing the warnings yourself so it's hard to test :grin: