### PR TITLE
Fix tests/jobscript/19 + others

### DIFF
--- a/tests/cylc-poll/16-execution-time-limit.t
+++ b/tests/cylc-poll/16-execution-time-limit.t
@@ -66,12 +66,14 @@ run_ok "${TEST_NAME}" grep -q 'health check settings: execution timeout=PT10S' \
 PREDICTED_POLL_TIME=$(time_offset \
     "$(cut -d ' ' -f 1 <<< "${LINE}")" \
     "$(sed 's/.*execution timeout=\([^,]\+\).*/\1/' <<< "${LINE}")")
-ACTUALL_POLL_TIME=$(sed -n \
+ACTUAL_POLL_TIME=$(sed -n \
     's/\(.*\) INFO - \[foo.1\] -(current:running)(polled) failed .*/\1/p' \
     "${LOG_FILE}")
 # Test execution timeout polling.
+# Main loop is roughly 1 second, but integer rounding may give an apparent 2
+# seconds delay, so set threshold as 2 seconds.
 run_ok "${TEST_NAME_BASE}-poll-time" \
-    cmp_times "${PREDICTED_POLL_TIME}" "${ACTUALL_POLL_TIME}" '1'
+    cmp_times "${PREDICTED_POLL_TIME}" "${ACTUAL_POLL_TIME}" '2'
 #-------------------------------------------------------------------------------
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/cylc-poll/16-execution-time-limit/suite.rc
+++ b/tests/cylc-poll/16-execution-time-limit/suite.rc
@@ -12,6 +12,7 @@
 [runtime]
     [[foo]]
         script = """
+            wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
             export PATH=/bin  # Disable task message.
             sleep 30  # Job must exceed exeuction time limit.
         """

--- a/tests/jobscript/19-exit-script.t
+++ b/tests/jobscript/19-exit-script.t
@@ -19,31 +19,50 @@
 # Test exit-script.
 
 . "$(dirname "${0}")/test_header"
-set_test_number 9
-
-install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
-
-run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+set_test_number 12
 
 # 1) Should run on normal successful job exit.
-run_ok "${TEST_NAME_BASE}-run" \
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-success" \
   cylc run --debug --no-detach "${SUITE_NAME}" 
 grep_ok 'Cheesy peas!' "${SUITE_RUN_DIR}/log/job/1/foo/01/job.out"
 grep_fail 'Oops!' "${SUITE_RUN_DIR}/log/job/1/foo/01/job.err"
+purge_suite "${SUITE_NAME}"
 
 # 2) Should not run on internal early EXIT.
-run_fail "${TEST_NAME_BASE}-run" \
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate --set=EXIT=true "${SUITE_NAME}"
+run_fail "${TEST_NAME_BASE}-exit" \
   cylc run --debug --no-detach --set=EXIT=true "${SUITE_NAME}" 
 grep_fail 'Cheesy peas!' "${SUITE_RUN_DIR}/log/job/1/foo/01/job.out"
 grep_ok 'EXIT Oops!' "${SUITE_RUN_DIR}/log/job/1/foo/01/job.err"
+purge_suite "${SUITE_NAME}"
 
 # 3) Should not run on external job TERM.
-cylc run --set=NSLEEP=30 "${SUITE_NAME}"
-sleep 3
-CYLC_JOB_PID=$(sed -n 's/^CYLC_JOB_PID=//p' "${SUITE_RUN_DIR}/log/job/1/foo/01/job.status")
-kill -s TERM $CYLC_JOB_PID
-sleep 5
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate --set=NSLEEP=30 "${SUITE_NAME}"
+cylc run --no-detach --set=NSLEEP=30 "${SUITE_NAME}" \
+    <'/dev/null' 1>'/dev/null' 2>&1 &
+SUITEPID=$!
+STFILE="${SUITE_RUN_DIR}/log/job/1/foo/01/job.status"
+for I in {1..60}; do
+    sleep 1
+    if grep -q 'CYLC_JOB_INIT_TIME=' "${STFILE}" 2>'/dev/null'; then
+        CYLC_JOB_PID="$(sed -n 's/^CYLC_JOB_PID=//p' "${STFILE}")"
+        kill -s 'TERM' "${CYLC_JOB_PID}"
+        break
+    fi
+done
+if wait "${SUITEPID}"; then
+    fail "${TEST_NAME_BASE}-term"  # Fail if suite returns zero
+else
+    ok "${TEST_NAME_BASE}-term"    # OK if suite returns non-zero
+fi
 grep_fail 'Cheesy peas!' "${SUITE_RUN_DIR}/log/job/1/foo/01/job.out"
 grep_ok 'TERM Oops!' "${SUITE_RUN_DIR}/log/job/1/foo/01/job.err"
-
 purge_suite "${SUITE_NAME}"
+
+exit

--- a/tests/shutdown/10-no-port-file.t
+++ b/tests/shutdown/10-no-port-file.t
@@ -34,7 +34,6 @@ if [[ -z "${PORT}" ]]; then
 fi
 rm -f "${SRVD}/contact"
 run_fail "${TEST_NAME_BASE}-stop-1" cylc stop "${SUITE_NAME}"
-cat "${TEST_NAME_BASE}-stop-1.stderr" >&2
 contains_ok "${TEST_NAME_BASE}-stop-1.stderr" <<__ERR__
 Contact info not found for suite "${SUITE_NAME}", suite not running?
 __ERR__

--- a/tests/shutdown/18-client-on-dead-suite.t
+++ b/tests/shutdown/18-client-on-dead-suite.t
@@ -28,12 +28,12 @@ init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
 __SUITERC__
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
-cylc run --hold "${SUITE_NAME}" 1>'cylc-run.out' 2>&1
+cylc run --hold --no-detach "${SUITE_NAME}" 1>'cylc-run.out' 2>&1 &
+MYPID=$!
 RUND="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
-MYPID=$(sed -n 's/^CYLC_SUITE_PROCESS=\([0-9]\+\) .*$/\1/p' \
-    "${RUND}/.service/contact")
+poll '!' test -f "${RUND}/.service/contact"
 kill "${MYPID}"  # Should leave behind the contact file
-wait "${MYPID}" || true
+wait "${MYPID}" 1>'/dev/null' 2>&1 || true
 MYHTTP=$(sed -n 's/^CYLC_COMMS_PROTOCOL=\(.\+\)$/\1/p' "${RUND}/.service/contact")
 MYHOST=$(sed -n 's/^CYLC_SUITE_HOST=\(.\+\)$/\1/p' "${RUND}/.service/contact")
 MYPORT=$(sed -n 's/^CYLC_SUITE_PORT=\(.\+\)$/\1/p' "${RUND}/.service/contact")


### PR DESCRIPTION
tests/jobscript/19: This test was very time dependent previously - especially on the third run of the suite. This fix should make it much more event dependent, and also ensure that result in the second run of the suite can no longer interfere with the logic in the third run.

tests/shutdown/10: Remove debug `cat`.

tests/shutdown/18: Fix background + `wait` logic.

tests/cylc-poll/16: Ensure started message is sent. Allow a bit more tolerance for integer rounding issues.